### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,53 +1,44 @@
 name: CI
+
 on: [push, pull_request]
+
+env:
+  DEFAULT_NODE_VERSION: 22.x
+
 jobs:
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-lint-modules-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-      - run: yarn install
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+          cache: yarn
+      - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn run lint
 
   test:
+    needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os:
+          - ubuntu-latest
         node-version:
-          - 14.x
-          - 16.x
           - 18.x
           - 20.x
           - 22.x
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - run: git config --global core.autocrlf input
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Ensure line endings are consistent
-        run: git config --global core.autocrlf input
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-test-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: Install dependencies
-        run: yarn install
-      - name: Build project
-        run: yarn run build
-      - name: Run tests
-        run: yarn run test
-      - name: Submit coverage results
-        uses: coverallsapp/github-action@master
+          cache: yarn
+      - run: yarn install --frozen-lockfile 
+      - run: yarn run test
+      - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ matrix.node-version }}
@@ -57,8 +48,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - name: Consolidate test coverage from different jobs
-        uses: coverallsapp/github-action@master
+      - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true


### PR DESCRIPTION
This is a set of updates to clean up the CI workflow file, by bumping the actions versions, dropping old Node versions, and using the built-in cache from actions/setup-node. The `--frozen-lockfile` flag is also added to `yarn install` steps to ensure whatever is in the lockfile gets installed as-is.