### PR TITLE
Make similarity config truly optional in components file

### DIFF
--- a/lib/Enhancer.ts
+++ b/lib/Enhancer.ts
@@ -530,6 +530,16 @@ export interface IEntitySimilarity {
   similarity: number;
 }
 
+export class SimilarityConfig implements ISimilarityConfig {
+  public constructor(
+    public parameterEmitterSimilaritiesPeople: IParameterEmitter,
+    public parameterEmitterSimilaritiesPosts: IParameterEmitter,
+    public parameterEmitterSimilaritiesComments: IParameterEmitter,
+    public maxSimilarities?: number,
+    public personTransformer?: TransformerReplaceIri,
+  ) {}
+}
+
 export interface ISimilarityConfig {
   /**
    * Parameter emitter that emits the calculated similarities for people
@@ -596,5 +606,5 @@ export interface IEnhancerOptions {
    * output similarities for persons to other entities in the
    * ldbc-snb data.
    */
-  similarityConfig?: ISimilarityConfig;
+  similarityConfig?: SimilarityConfig;
 }

--- a/lib/Enhancer.ts
+++ b/lib/Enhancer.ts
@@ -530,6 +530,7 @@ export interface IEntitySimilarity {
   similarity: number;
 }
 
+// Avoids Components.js generator flattening the params of this config, to allow this config to be optional.
 export class SimilarityConfig implements ISimilarityConfig {
   public constructor(
     public parameterEmitterSimilaritiesPeople: IParameterEmitter,

--- a/test/Enhancer-test.ts
+++ b/test/Enhancer-test.ts
@@ -1,7 +1,7 @@
 import { Readable, PassThrough } from 'node:stream';
 import { DataFactory } from 'rdf-data-factory';
 import 'jest-rdf';
-import { Enhancer } from '../lib/Enhancer';
+import { Enhancer, SimilarityConfig } from '../lib/Enhancer';
 import type { IEnhancementHandler } from '../lib/handlers/IEnhancementHandler';
 import type { IParameterEmitter } from '../lib/parameters/IParameterEmitter';
 import { TransformerReplaceIri } from '../lib/transformers/TransformerReplaceIri';
@@ -833,6 +833,56 @@ sn:comment1 snvoc:hasCreator sn:person2 .`;
           ],
         });
       });
+    });
+  });
+  describe('SimilarityConfig', () => {
+    let mockEmitterPeople: IParameterEmitter;
+    let mockEmitterPosts: IParameterEmitter;
+    let mockEmitterComments: IParameterEmitter;
+    let mockTransformer: TransformerReplaceIri;
+
+    beforeEach(() => {
+      // Create barebones mock objects that satisfy the TypeScript compiler
+      mockEmitterPeople = <IParameterEmitter> {};
+      mockEmitterPosts = <IParameterEmitter> {};
+      mockEmitterComments = <IParameterEmitter> {};
+      mockTransformer = <TransformerReplaceIri> {};
+    });
+
+    it('initializes correctly with only the required parameters', () => {
+      const config = new SimilarityConfig(
+        mockEmitterPeople,
+        mockEmitterPosts,
+        mockEmitterComments,
+      );
+
+      expect(config.parameterEmitterSimilaritiesPeople).toBe(mockEmitterPeople);
+      expect(config.parameterEmitterSimilaritiesPosts).toBe(mockEmitterPosts);
+      expect(config.parameterEmitterSimilaritiesComments).toBe(mockEmitterComments);
+
+      // Ensure optional parameters remain undefined when not provided
+      expect(config.maxSimilarities).toBeUndefined();
+      expect(config.personTransformer).toBeUndefined();
+    });
+
+    it('initializes correctly with all parameters provided', () => {
+      const maxSimilarities = 100;
+
+      const config = new SimilarityConfig(
+        mockEmitterPeople,
+        mockEmitterPosts,
+        mockEmitterComments,
+        maxSimilarities,
+        mockTransformer,
+      );
+
+      expect(config.parameterEmitterSimilaritiesPeople).toBe(mockEmitterPeople);
+      expect(config.parameterEmitterSimilaritiesPosts).toBe(mockEmitterPosts);
+      expect(config.parameterEmitterSimilaritiesComments).toBe(mockEmitterComments);
+
+      // Ensure optional parameters are properly assigned
+      expect(config.maxSimilarities).toBe(maxSimilarities);
+      expect(config.personTransformer).toBe(mockTransformer);
     });
   });
 });


### PR DESCRIPTION
Due to components.js generator flattening the `similarityConfig` parameter of the `Enhancer` class, some of the similarity-only configuration options became required. This breaks default `SolidBench` configurations.
This change will make sure that the intended parameter structure is respected.

When this is merged this will also require a change upstream in SolidBench.